### PR TITLE
fix: combine news and blogs remove previous testfest events

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -179,13 +179,7 @@ modules:
             image: fas users
             items:
               - 
-                title: Last Virtual Event
-                subtitle: 2021-Nov-10
-                status: pending  # options "active" = on; "deactive" = off; "pending" = in transition; "highlight" = extra visible
-                url: https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/wiki/Virtual-TestFest-Mar-2021
-                target: _blank
-              - 
-                title: Previous
+                title: Previous TestFests
                 subtitle: Events
                 status: active  # options "active" = on; "deactive" = off; "pending" = in transition; "highlight" = extra visible
                 url: https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/wiki/Virtual-TestFest-Mar-2021

--- a/content/index.md
+++ b/content/index.md
@@ -182,7 +182,7 @@ modules:
                 title: Previous TestFests
                 subtitle: Events
                 status: active  # options "active" = on; "deactive" = off; "pending" = in transition; "highlight" = extra visible
-                url: https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/wiki/Virtual-TestFest-Mar-2021
+                url: https://guidelines.openmobilealliance.org/testfests
                 target: _blank
   -
     name: RowSeparator

--- a/content/menus.md
+++ b/content/menus.md
@@ -29,12 +29,8 @@
       description: News & BLog pages of the OMA DMSE
       class: text-uppercase
       items:
-        - 
-           title: Blogs
-           url: /blogs/
-           class: text-uppercase
         -
-           title: News
+           title: News & Blogs
            url: /news/
            class: text-uppercase
         -

--- a/content/news/2020-01-23-Lw2M2M-5G.md
+++ b/content/news/2020-01-23-Lw2M2M-5G.md
@@ -1,5 +1,5 @@
 ---
-layout: blog
+layout: news
 image: 
 title: White Paper - OMA LwM2M - Ready for 5G
 subtitle: LwM2M & 5G
@@ -7,7 +7,7 @@ description: OMA LwM2M is ready for 5G
 url: 
 date: 2020-Jan-23
 by: OMA SpecWorks
-author: OMA DMSE
+homepage: 4
 tags: 
     - 5G
     - v1.2

--- a/content/news/2020-12-09-lwm2m-release.md
+++ b/content/news/2020-12-09-lwm2m-release.md
@@ -1,5 +1,5 @@
 ---
-layout: blog
+layout: news
 image:
 title: LwM2M v1.2 is now available!
 subtitle: Latest LwM2M Protocol version
@@ -7,7 +7,7 @@ description: The standardization work on the LwM2M v1.2 specification has been c
 url: 
 date: 2020-Dec-09
 by:  OMA SpecWorks
-author: Hannes Tschofening
+homepage: 5
 tags:
     - v1.2
     - Release

--- a/content/news/2022-04-12-nuSIM_objects.md
+++ b/content/news/2022-04-12-nuSIM_objects.md
@@ -1,13 +1,13 @@
 ---
-layout: blog
+layout: news
 image: /images/news/nuSIM_Label_1C_tagline_3C.png
 title: LwM2M Objects for nuSIM Integrated SIM
 subtitle: OMA SpecWorks defines new Objects for nuSIM
 description: nuSIM is an optimized iSIM solution for IoT
 url: 
 date: 2022-Apr-12
-by:  Jean Trakinat
-author: Jean Trakinat
+by:  OMASpecWorks
+homepage: 6
 tags:
 ---
 


### PR DESCRIPTION
This PR contains changes suggested by Jean, Hannes and Matt:

- [x] combined "News" and "Blogs" under a single tab and keep look & feel like in "News" (called CARDS)
- [x] change in blog "LwM2M Objects for nuSIM Integrated SIM" from Jean Trakinat to OMASpecWorks
- [x] remove "Last Virtual TestFest" TestFest bubble and rename "Previous" to "Previous TestFests"
- [ ] point "Previous TestFest" bubble to new Documentation page (pending)

To run locally these changes, clone this repo and run locally the command
`npm run dev` 