### PR TITLE
delete closed testfest and add new post-workshop for utilities

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -221,23 +221,18 @@ modules:
                 url: https://guidelines.openmobilealliance.org/testfests
                 target: _blank
               - 
-                title: Post-Workshop Utilities
+                title: Utility Post-Workshop I
                 subtitle: Events
                 status: active  # options "active" = on; "deactive" = off; "pending" = in transition; "highlight" = extra visible
                 url: http://21247113.hs-sites.com/iot-for-utilities-workshop-1
                 target: _blank
               - 
-                title: Workshop Utilities
+                title: Utility Post-Workshop II
                 subtitle: Events
-                status: highlight  # options "active" = on; "deactive" = off; "pending" = in transition; "highlight" = extra visible
-                url: /news/2023-10-03-outreach-utility-november/
+                status: active  # options "active" = on; "deactive" = off; "pending" = in transition; "highlight" = extra visible
+                url: http://21247113.hs-sites.com/unlocking-utility-benefits-with-lwm2m-3
                 target: _blank
-              - 
-                title: Virtual Test Event
-                subtitle: Events
-                status: highlight  # options "active" = on; "deactive" = off; "pending" = in transition; "highlight" = extra visible
-                url: https://21247113.hs-sites.com/unlocking-utility-benefits-with-lwm2m-2
-                target: _blank
+             
   -
     name: RowText
     text: (*) _Note - The Open Mobile Alliance is not responsible for the content of any particular implementation and does not endorse any particular implementation._


### PR DESCRIPTION
This is similar to what was proposed in [PR#88](https://github.com/OpenMobileAlliance/oma_github_pages/pull/88) , but the second Post-workshop is pointed to the new landing page.